### PR TITLE
 async callback test for simple-promise not work when time overdue

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,6 +40,7 @@ function traverse(ctx, keyword, item) {
         result = Promise.reject(e);
       }
       result[thenArraySymbol] = result[thenArraySymbol].concat(cbObject.next);
+      result[checkState]();
     } else if (cbObject.next.length) {
       traverse(ctx, keyword, cbObject.next);
     }

--- a/test/async.js
+++ b/test/async.js
@@ -1,0 +1,25 @@
+/**
+ * Created by slashhuang on 2016/11/1.
+ */
+const Promise = require('../');
+
+describe('async promise', () => {
+  it('should work', (done) => {
+    const result = 1;
+    const pro1 = new Promise(function (resolve, reject) {
+      setTimeout(resolve,1000,1)
+    });
+    const pro2 = pro1.then(val => {
+        console.log(val);
+        return new Promise((res,rej)=>{
+            res(2);
+        })
+    });
+    setTimeout(()=>{
+        pro2.then(val=>{
+            console.log(val);
+            done()
+        });
+    },2000)
+  });
+});


### PR DESCRIPTION
当setTimeout时间大于Promise运行周期时间时，由于状态仅仅保存在runtime，导致test/async.js未通过。
